### PR TITLE
Avoid segmentation fault with empty string

### DIFF
--- a/modules/core/src/command_line_parser.cpp
+++ b/modules/core/src/command_line_parser.cpp
@@ -9,6 +9,8 @@ static const char* noneValue = "<none>";
 
 static String cat_string(const String& str)
 {
+    if (str.length() == 0)
+        return String("");
     int left = 0, right = (int)str.length();
     while( left <= right && str[left] == ' ' )
         left++;


### PR DESCRIPTION
When an empty string is passed to `cat_string()`, the function causes a segmentation fault by attempting to access the first character of the empty string. 

resolves #7936


### This pullrequest changes

This change adds a test to return an empty string in the case of an empty string as input to `cat_string()`.